### PR TITLE
Allow empty album and/or artist

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -215,7 +215,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         return track
 
     def _to_mopidy_album(self, song):
-        name = song['album']
+        name = song.get('album', '')
         artist = self._to_mopidy_album_artist(song)
         date = unicode(song.get('year', 0))
         uri = 'gmusic:album:' + self._create_id(artist.name + name + date)
@@ -230,7 +230,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         return album
 
     def _to_mopidy_artist(self, song):
-        name = song['artist']
+        name = song.get('artist', '')
         uri = 'gmusic:artist:' + self._create_id(name)
         artist = Artist(
             uri=uri,
@@ -241,7 +241,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
     def _to_mopidy_album_artist(self, song):
         name = song.get('albumArtist', '')
         if name.strip() == '':
-            name = song['artist']
+            name = song.get('artist', '')
         uri = 'gmusic:artist:' + self._create_id(name)
         artist = Artist(
             uri=uri,
@@ -278,14 +278,14 @@ class GMusicLibraryProvider(backend.LibraryProvider):
             date=date)
 
     def _aa_to_mopidy_artist(self, song):
-        name = song['artist']
+        name = song.get('artist', '')
         return Artist(
             name=name)
 
     def _aa_to_mopidy_album_artist(self, album_info):
         name = album_info.get('albumArtist', '')
         if name.strip() == '':
-            name = album_info['artist']
+            name = album_info.get('artist', '')
         return Artist(
             name=name)
 


### PR DESCRIPTION
I was getting errors like:

ERROR    Unhandled exception in GMusicBackend (urn:uuid:[filtered]):
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/pykka/actor.py", line 191, in _actor_loop
    self.on_start()
  File "/usr/local/lib/python2.7/dist-packages/mopidy_gmusic/actor.py", line 30, in on_start
    self.library.refresh()
  File "/usr/local/lib/python2.7/dist-packages/mopidy_gmusic/library.py", line 124, in refresh
    self._to_mopidy_track(song)
  File "/usr/local/lib/python2.7/dist-packages/mopidy_gmusic/library.py", line 207, in _to_mopidy_track
    artists=[self._to_mopidy_artist(song)],
  File "/usr/local/lib/python2.7/dist-packages/mopidy_gmusic/library.py", line 233, in _to_mopidy_artist
    name = song['artist']
KeyError: u'artist'
