### PR TITLE
Set artist as Unknown Artist instead of crashing when artist missing

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -230,10 +230,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         return album
 
     def _to_mopidy_artist(self, song):
-        try:
-            name = song['artist']
-        except KeyError:
-            name = 'Unknown Artist'
+        name = song.get('artist','Unknown Artist')
         uri = 'gmusic:artist:' + self._create_id(name)
         artist = Artist(
             uri=uri,

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -230,7 +230,10 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         return album
 
     def _to_mopidy_artist(self, song):
-        name = song['artist']
+        try:
+            name = song['artist']
+        except KeyError:
+            name = 'Unknown Artist'
         uri = 'gmusic:artist:' + self._create_id(name)
         artist = Artist(
             uri=uri,


### PR DESCRIPTION
Hey,

First, thanks for building this! I've finally got a fantastic CLI client for Google Music. This is a minor fix to keep it from crashing on tracks with no artist tag. Traceback:

    INFO     Starting Mopidy core
    ERROR    Unhandled exception in GMusicBackend (urn:uuid:a1f228d7-e86f-48d4-aa9d-c25f83fa36e0):
    Traceback (most recent call last):
      File "/usr/local/lib/python2.7/dist-packages/pykka/actor.py", line 191, in _actor_loop
        self.on_start()
      File "/home/jai/.local/lib/python2.7/site-packages/mopidy_gmusic/actor.py", line 30, in on_start
        self.library.refresh()
      File "/home/jai/.local/lib/python2.7/site-packages/mopidy_gmusic/library.py", line 124, in refresh
        self._to_mopidy_track(song)
      File "/home/jai/.local/lib/python2.7/site-packages/mopidy_gmusic/library.py", line 207, in _to_mopidy_track
        artists=[self._to_mopidy_artist(song)],
      File "/home/jai/.local/lib/python2.7/site-packages/mopidy_gmusic/library.py", line 233, in _to_mopidy_artist
        name = song['artist']
    KeyError: u'artist'

I'm using "Unknown Artist" as a fallback, but there might be a better more-standardy thing that I'm not aware of.