### PR TITLE
Check for API login result instead of catching an exception

### DIFF
--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -17,10 +17,10 @@ class GMusicSession(object):
     def login(self, username, password, deviceid):
         if self.api.is_authenticated():
             self.api.logout()
-        try:
-            self.api.login(username, password)
-        except CallFailure as error:
-            logger.error(u'Failed to login as "%s": %s', username, error)
+
+        if not self.api.login(username, password):
+            logger.error(u'Failed to login as "%s"', username)
+
         if self.api.is_authenticated():
             if deviceid is None:
                 self.deviceid = self.get_deviceid(username, password)


### PR DESCRIPTION
gmusicapi does not throw an exception on login failure, instead it [returns](https://github.com/simon-weber/Unofficial-Google-Music-API/blob/develop/gmusicapi/clients/mobileclient.py#L27) a boolean. Since exception is never caught on failure it's hard to understand why it doesn't work from non-debug logs.
