### PR TITLE
Add IFL radio station (bump gmusicapi requirement to 7.0.1).

### DIFF
--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -43,6 +43,8 @@ def endpoint(default=None, require_all_access=False):
 
 class GMusicSession(object):
 
+    IFL_STATION_DICT = {'id': 'IFL', 'name': "I'm Feeling Lucky"}
+
     def __init__(self, all_access, api=None):
         self.all_access = all_access
         if api is None:
@@ -127,7 +129,7 @@ class GMusicSession(object):
         stations.reverse()
 
         # Add IFL radio on top
-        stations.insert(0, {'id': 'IFL', 'name': 'I\'m Feeling Lucky'})
+        stations.insert(0, self.IFL_STATION_DICT)
 
         if num_stations is not None and num_stations > 0:
             # Limit radio stations

--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -129,7 +129,8 @@ class GMusicSession(object):
         stations.reverse()
 
         # Add IFL radio on top
-        stations.insert(0, self.IFL_STATION_DICT)
+        if self.api.is_authenticated():
+            stations.insert(0, self.IFL_STATION_DICT)
 
         if num_stations is not None and num_stations > 0:
             # Limit radio stations

--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -127,8 +127,7 @@ class GMusicSession(object):
         stations.reverse()
 
         # Add IFL radio on top
-        # XXX This causes a crash. See simon-weber/gmusicapi#365
-        # stations.insert(0, {'id': 'IFL', 'name': 'I\'m Feeling Lucky'})
+        stations.insert(0, {'id': 'IFL', 'name': 'I\'m Feeling Lucky'})
 
         if num_stations is not None and num_stations > 0:
             # Limit radio stations

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 1.0',
         'Pykka >= 1.1',
-        'gmusicapi >= 6.0',
+        'gmusicapi >= 7.0.1',
         'requests >= 2.0',
     ],
     entry_points={

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -73,11 +73,8 @@ class LibraryTest(unittest.TestCase):
 
     def test_browse_radio(self):
         refs = self.backend.library.browse('gmusic:radio')
-
-        ifl_id, ifl_name = session_lib.GMusicSession.IFL_STATION_DICT.values()
-        ifl_uri = 'gmusic:radio:{0}'.format(ifl_id)
-        ifl_station = models.Ref(name=ifl_name, type='directory', uri=ifl_uri)
-        self.assertEqual(refs, [ifl_station])
+        # tests should be unable to fetch stations :(
+        self.assertEqual(refs, [])
 
     def test_browse_station(self):
         refs = self.backend.library.browse('gmusic:radio:invalid_stations_id')

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,6 +1,10 @@
 import unittest
 
+from mopidy.backend import models
+
 from mopidy_gmusic import actor as backend_lib
+
+from mopidy_gmusic import session as session_lib
 
 from tests.test_extension import ExtensionTest
 
@@ -69,9 +73,11 @@ class LibraryTest(unittest.TestCase):
 
     def test_browse_radio(self):
         refs = self.backend.library.browse('gmusic:radio')
-        # tests should be unable to fetch stations :(
-        self.assertIsNotNone(refs)
-        self.assertEqual(refs, [])
+
+        ifl_id, ifl_name = session_lib.GMusicSession.IFL_STATION_DICT.values()
+        ifl_uri = 'gmusic:radio:{0}'.format(ifl_id)
+        ifl_station = models.Ref(name=ifl_name, type='directory', uri=ifl_uri)
+        self.assertEqual(refs, [ifl_station])
 
     def test_browse_station(self):
         refs = self.backend.library.browse('gmusic:radio:invalid_stations_id')
@@ -89,7 +95,7 @@ class LibraryTest(unittest.TestCase):
         self.assertEqual(refs, [])
 
     def test_lookup_invalid_artist(self):
-        refs = self.backend.library.lookup('gmusic:artis:invalid_uri')
+        refs = self.backend.library.lookup('gmusic:artist:invalid_uri')
         # tests should be unable to fetch any content :(
         self.assertEqual(refs, [])
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -239,8 +239,17 @@ class TestSearchAllAccess(object):
 
 class TestGetAllStations(object):
 
+    @classmethod
+    def setup_class(self):
+        session = online_session()
+        self.stations = [{'id': 'Test', 'name': 'First test station'},
+                         {'id': 'Test2', 'name': 'Second test station'}]
+        session.api.get_all_stations.return_value = self.stations
+        self.radio_stations = session.get_radio_stations()
+        self.ifl_station_dict = session_lib.GMusicSession.IFL_STATION_DICT
+
     def test_when_offline(self, offline_session):
-        assert offline_session.get_all_stations() == []
+        assert offline_session.get_all_stations() == [self.ifl_station_dict]
 
     def test_when_online(self, online_session):
         online_session.api.get_all_stations.return_value = mock.sentinel.rv
@@ -248,6 +257,16 @@ class TestGetAllStations(object):
         assert online_session.get_all_stations() is mock.sentinel.rv
 
         online_session.api.get_all_stations.assert_called_once_with()
+
+    def test_when_online_ifl_is_first_radio_station(self, online_session):
+        assert self.radio_stations[0] == self.ifl_station_dict
+
+    def test_when_online_retrieves_radio_stations(self, online_session):
+        stations = self.stations[:]
+        stations.insert(0, self.ifl_station_dict)
+
+        for station in stations:
+            assert station in self.radio_stations
 
 
 class TestGetStationTracks(object):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -249,7 +249,7 @@ class TestGetAllStations(object):
         self.ifl_station_dict = session_lib.GMusicSession.IFL_STATION_DICT
 
     def test_when_offline(self, offline_session):
-        assert offline_session.get_all_stations() == [self.ifl_station_dict]
+        assert offline_session.get_all_stations() == []
 
     def test_when_online(self, online_session):
         online_session.api.get_all_stations.return_value = mock.sentinel.rv


### PR DESCRIPTION
The code was commented out due to an unresolved issue in simon-weber/gmusicapi#365. This has been solved and the IFL radio stations are now working.