### PR TITLE
Support medium and low bitrate

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -435,7 +435,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
             disc_no=song.get('discNumber', 1),
             date=unicode(song.get('year', 0)),
             length=int(song['durationMillis']),
-            bitrate=320)
+            bitrate=self.backend.config['gmusic']['bitrate'])
         self.tracks[uri] = track
         return track
 
@@ -504,7 +504,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
             disc_no=song.get('discNumber', 1),
             date=album.date,
             length=int(song['durationMillis']),
-            bitrate=320)
+            bitrate=self.backend.config['gmusic']['bitrate'])
         self.aa_tracks[uri] = track
         return track
 
@@ -567,7 +567,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
             disc_no=track.get('discNumber', 1),
             date=unicode(track.get('year', 0)),
             length=int(track['durationMillis']),
-            bitrate=320)
+            bitrate=self.backend.config['gmusic']['bitrate'])
 
     def _aa_search_artist_to_mopidy_artist(self, search_artist):
         artist = search_artist['artist']

--- a/mopidy_gmusic/playback.py
+++ b/mopidy_gmusic/playback.py
@@ -18,7 +18,6 @@ class GMusicPlaybackProvider(backend.PlaybackProvider):
     def translate_uri(self, uri):
         track_id = uri.rsplit(':')[-1]
 
-        # TODO Support medium and low bitrate
         quality = BITRATES[self.backend.config['gmusic']['bitrate']]
         stream_uri = self.backend.session.get_stream_url(
             track_id, quality=quality)


### PR DESCRIPTION
- Remove old TODO comment from code
- Read bitrate from config.
  - The different bitrates low (128kbit/s), med (160kbit/s) and hi (320kbit/s) have been supported since simon-weber/gmusicapi#319 (gmusicapi >= 5.0.0).

Also, gmusicapi default to "hi" quality and the code formerly built mopidy models using a bitrate of 320. Thus, you might want to consider switching to 320 as default bitrate in the config.
