### PR TITLE
No more fuzzy search. Also, filter by search fields.

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -336,24 +336,82 @@ class GMusicLibraryProvider(backend.LibraryProvider):
                 logger.info(
                     'Searching Google Play Music All Access for: %s',
                     values[0])
-                res = self.backend.session.search_all_access(
+                results = self.backend.session.search_all_access(
                     values[0], max_results=50)
-                if res is None:
+                results = self.filter_search_results(results, query)
+                if results is None:
                     return [], [], []
 
                 albums = [
-                    self._aa_search_album_to_mopidy_album(album_res)
-                    for album_res in res['album_hits']]
+                    self._aa_search_album_to_mopidy_album(album_results)
+                    for album_results in results['album_hits']]
                 artists = [
-                    self._aa_search_artist_to_mopidy_artist(artist_res)
-                    for artist_res in res['artist_hits']]
+                    self._aa_search_artist_to_mopidy_artist(artist_results)
+                    for artist_results in results['artist_hits']]
                 tracks = [
-                    self._aa_search_track_to_mopidy_track(track_res)
-                    for track_res in res['song_hits']]
+                    self._aa_search_track_to_mopidy_track(track_results)
+                    for track_results in results['song_hits']]
 
                 return tracks, artists, albums
 
         return [], [], []
+
+    def filter_search_results(self, search_results, query):
+        '''Filter the `search_results` using the criterions given in `query`.
+        - Multiple criterions are combined using AND.
+        - Search is case insensitive
+        - Fuzzy search is disabled
+          (exact strings must appear in the queried fields)'''
+        for key, results in search_results.items():
+            results[:] = [result for result in results if
+                          self.is_query_in_search_result(result, key, query)]
+        return search_results
+
+    def get_result_key_from_search_results_key(self, key):
+        result_key = key.replace('_hits', '')
+        if result_key == 'song':
+            return 'track'
+
+        return result_key
+
+    def is_query_in_search_result(self, result, key, query):
+        result_key = self.get_result_key_from_search_results_key(key)
+        musical_work = result[result_key]
+
+        for musical_work_type, value in query.items():
+            is_in_search_result = False
+            fields = self.determine_google_music_fields(result_key,
+                                                        musical_work_type)
+            # a list with a single element is provided. Thus, unpack it:
+            value = value[0].lower()
+
+            for field in fields:
+                try:
+                    if value in musical_work[field].lower():
+                        is_in_search_result = True
+                        break
+                except KeyError:
+                    pass
+
+            if not is_in_search_result:
+                return False
+        return True
+
+    def determine_google_music_fields(self, result_key, field):
+        if field and field != 'any':
+            special_cases = ['artist', 'playlist']
+
+            if field in special_cases and field == result_key:
+                return ['name']
+
+            elif field == 'track_name':
+                return ['title']
+
+            else:
+                return [field]
+        else:
+            return ['name', 'artist', 'album', 'albumArtist', 'title',
+                    'year']
 
     def _search_library(self, query=None, uris=None):
         if query is None:


### PR DESCRIPTION
I have forked the `develop` branch and thus also created this PR against it instead of `master`. Moreover, this change is presumably discussion worthy.

---
**The current situation:**

The gmusicapi does not support to search by field. Thus, when searching for artists with the name _"XYZ"_, results will be returned of that artist and also of artist _"ABC"_ with their album _"XYZ"_. Furthermore, as the search is fuzzy, the song _"XYY"_ by the band _"The ABCs"_ will also be returned as a valid result. (Note, these are not real artist, release or track names but you can quickly find similar examples e.g. by searching for the artist _"Escapado"_)

---
**This pull request:**

Search will now be filtered so that the exact searched terms must appear within the given fields. No more fuzzy search, no more albums being returned when they solely match the artist names.