### PR TITLE
Fix broken all access search

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -295,8 +295,8 @@ class GMusicLibraryProvider(backend.LibraryProvider):
 
         lib_tracks, lib_artists, lib_albums = self._search_library(query, uris)
 
-        if query and self.all_access:
-            aa_tracks, aa_artists, aa_albums = self._search_all_access(
+        if query:
+            aa_tracks, aa_artists, aa_albums = self._search(
                 query, uris)
             for aa_artist in aa_artists:
                 lib_artists.add(aa_artist)
@@ -324,7 +324,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
                             artists=lib_artists,
                             albums=lib_albums)
 
-    def _search_all_access(self, query=None, uris=None):
+    def _search(self, query=None, uris=None):
         for (field, values) in query.iteritems():
             if not hasattr(values, '__iter__'):
                 values = [values]
@@ -334,9 +334,9 @@ class GMusicLibraryProvider(backend.LibraryProvider):
             if field in [
                     'track_name', 'album', 'artist', 'albumartist', 'any']:
                 logger.info(
-                    'Searching Google Play Music All Access for: %s',
+                    'Searching Google Play Music for: %s',
                     values[0])
-                res = self.backend.session.search_all_access(
+                res = self.backend.session.search(
                     values[0], max_results=50)
                 if res is None:
                     return [], [], []

--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -112,7 +112,7 @@ class GMusicSession(object):
             max_top_tracks=max_top_tracks,
             max_rel_artist=max_rel_artist)
 
-    @endpoint(default=None, require_all_access=True)
+    @endpoint(default=None, require_all_access=False)
     def search_all_access(self, query, max_results=50):
         return self.api.search(query, max_results=max_results)
 

--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -114,7 +114,7 @@ class GMusicSession(object):
 
     @endpoint(default=None, require_all_access=True)
     def search_all_access(self, query, max_results=50):
-        return self.api.search_all_access(query, max_results=max_results)
+        return self.api.search(query, max_results=max_results)
 
     @endpoint(default=list)
     def get_all_stations(self):

--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -113,7 +113,7 @@ class GMusicSession(object):
             max_rel_artist=max_rel_artist)
 
     @endpoint(default=None, require_all_access=False)
-    def search_all_access(self, query, max_results=50):
+    def search(self, query, max_results=50):
         return self.api.search(query, max_results=max_results)
 
     @endpoint(default=list)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -97,3 +97,7 @@ class LibraryTest(unittest.TestCase):
         refs = self.backend.library.lookup('gmusic:track:invalid_uri')
         # tests should be unable to fetch any content :(
         self.assertEqual(refs, [])
+
+    def test_search(self):
+        refs = self.backend.library.search({'artist': ['abba']})
+        self.assertIsNotNone(refs)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -231,10 +231,12 @@ class TestSearchAllAccess(object):
     def test_without_all_access(self, online_session, caplog):
         online_session.all_access = False
 
-        assert online_session.search_all_access('abba') is None
+        online_session.api.search.return_value = mock.sentinel.rv
+
+        assert online_session.search_all_access('abba') is mock.sentinel.rv
         assert (
-            'Google Play Music All Access is required for search_all_access()'
-            in caplog.text())
+            'Google Play Music All Access is required for'
+            not in caplog.text())
 
 
 class TestGetAllStations(object):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -217,12 +217,12 @@ class TestGetArtistInfo(object):
 class TestSearchAllAccess(object):
 
     def test_when_offline(self, offline_session):
-        assert offline_session.search_all_access('abba') is None
+        assert offline_session.search('abba') is None
 
     def test_when_online(self, online_session):
         online_session.api.search.return_value = mock.sentinel.rv
 
-        result = online_session.search_all_access('abba', max_results=10)
+        result = online_session.search('abba', max_results=10)
 
         assert result is mock.sentinel.rv
         online_session.api.search.assert_called_once_with(
@@ -233,7 +233,7 @@ class TestSearchAllAccess(object):
 
         online_session.api.search.return_value = mock.sentinel.rv
 
-        assert online_session.search_all_access('abba') is mock.sentinel.rv
+        assert online_session.search('abba') is mock.sentinel.rv
         assert (
             'Google Play Music All Access is required for'
             not in caplog.text())

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -220,12 +220,12 @@ class TestSearchAllAccess(object):
         assert offline_session.search_all_access('abba') is None
 
     def test_when_online(self, online_session):
-        online_session.api.search_all_access.return_value = mock.sentinel.rv
+        online_session.api.search.return_value = mock.sentinel.rv
 
         result = online_session.search_all_access('abba', max_results=10)
 
         assert result is mock.sentinel.rv
-        online_session.api.search_all_access.assert_called_once_with(
+        online_session.api.search.assert_called_once_with(
             'abba', max_results=10)
 
     def test_without_all_access(self, online_session, caplog):


### PR DESCRIPTION
Issue #116 
The gmusicapi dependency has been updated. The search_all_access() method was renamed to search(). http://unofficial-google-music-api.readthedocs.io/en/latest/reference/mobileclient.html#search.

I was able to reproduce the issue using ncmpcpp with search type of "match if tag contains searched phrase (no regexes)"

Here is the commit which caused the change. https://github.com/simon-weber/gmusicapi/commit/4419d0e10812d5b8861d0fafb45b74e8a1b63f27