### PR TITLE
Don't throw an error if an unauthenticated user checks all_access

### DIFF
--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -4,6 +4,7 @@ import functools
 import logging
 
 import gmusicapi
+from gmusicapi.exceptions import NotLoggedIn
 
 import requests
 
@@ -68,7 +69,10 @@ class GMusicSession(object):
     @property
     def all_access(self):
         if self._all_access is None:
-            return self.api.is_subscribed
+            try:
+                return self.api.is_subscribed
+            except NotLoggedIn:
+                return False
 
         return self._all_access
 


### PR DESCRIPTION
There was a slight issue with #123 where pykka will check all properties on the backends, so we need to handle this in case it gets accessed before we've logged in.