### PR TITLE
Reenable tracks browsing

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -33,8 +33,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         self._root = []
         self._root.append(Ref.directory(uri='gmusic:album', name='Albums'))
         self._root.append(Ref.directory(uri='gmusic:artist', name='Artists'))
-        # browsing all tracks results in connection timeouts
-        # self._root.append(Ref.directory(uri='gmusic:track', name='Tracks'))
+        self._root.append(Ref.directory(uri='gmusic:track', name='Tracks'))
 
         if self._radio_stations_in_browse:
             self._root.append(Ref.directory(uri='gmusic:radio',
@@ -76,6 +75,14 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         artist -- a mopidy artist to cache
         """
         self.aa_artists[artist.uri] = artist
+
+    def _browse_tracks(self):
+        tracks = list(self.tracks.values())
+        tracks.sort(key=lambda ref: ref.name)
+        refs = []
+        for track in tracks:
+            refs.append(track_to_ref(track))
+        return refs
 
     def _browse_albums(self):
         refs = []
@@ -125,6 +132,10 @@ class GMusicLibraryProvider(backend.LibraryProvider):
             return self._root
 
         parts = uri.split(':')
+
+        # tracks
+        if uri == 'gmusic:track':
+            return self._browse_tracks()
 
         # albums
         if uri == 'gmusic:album':

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -44,10 +44,20 @@ class LibraryTest(unittest.TestCase):
         self.assertTrue(found, 'ref \'gmusic:artist\' not found')
         found = False
         for ref in refs:
+            if ref.uri == 'gmusic:track':
+                found = True
+                break
+        self.assertTrue(found, 'ref \'gmusic:track\' not found')
+        found = False
+        for ref in refs:
             if ref.uri == 'gmusic:radio':
                 found = True
                 break
         self.assertTrue(found, 'ref \'gmusic:radio\' not found')
+
+    def test_browse_tracks(self):
+        refs = self.backend.library.browse('gmusic:track')
+        self.assertIsNotNone(refs)
 
     def test_browse_artist(self):
         refs = self.backend.library.browse('gmusic:artist')


### PR DESCRIPTION
All these values are already cached, so there's very little reason to leave this disabled.