### PR TITLE
Ensure all radio station tracks are cached

### DIFF
--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -138,8 +138,7 @@ class GMusicSession(object):
         stations.reverse()
 
         # Add IFL radio on top
-        # XXX This causes a crash. See simon-weber/gmusicapi#365
-        # stations.insert(0, {'id': 'IFL', 'name': 'I\'m Feeling Lucky'})
+        stations.insert(0, {'id': 'IFL', 'name': 'I\'m Feeling Lucky'})
 
         if num_stations is not None and num_stations > 0:
             # Limit radio stations

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,5 +1,7 @@
 import unittest
 
+from mopidy.models import Ref
+
 from mopidy_gmusic import backend as backend_lib
 
 from tests.test_extension import ExtensionTest
@@ -81,7 +83,8 @@ class LibraryTest(unittest.TestCase):
         refs = self.backend.library.browse('gmusic:radio')
         # tests should be unable to fetch stations :(
         self.assertIsNotNone(refs)
-        self.assertEqual(refs, [])
+        self.assertEqual(refs, [Ref.directory(uri='gmusic:radio:IFL',
+                                              name="I'm Feeling Lucky")])
 
     def test_browse_station(self):
         refs = self.backend.library.browse('gmusic:radio:invalid_stations_id')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -242,7 +242,9 @@ class TestSearchAllAccess(object):
 class TestGetAllStations(object):
 
     def test_when_offline(self, offline_session):
-        assert offline_session.get_all_stations() == []
+        assert offline_session.get_all_stations() == [
+            {'id': 'IFL', 'name': "I'm Feeling Lucky"}
+        ]
 
     def test_when_online(self, online_session):
         online_session.api.get_all_stations.return_value = mock.sentinel.rv


### PR DESCRIPTION
Fixes #134

This also replaces #110, as it also re-enables the IFL playlist.