### PR TITLE
Try to guess which device ID to use during login

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,24 +81,25 @@ are the default config values::
     # Limit the number or tracks for each radio station
     radio_tracks_count = 25
 
-Google Play Music requires all clients to provide a device ID. By default,
-Mopidy-GMusic will use your system's MAC address as the device ID. As Google
-`puts some limits <https://support.google.com/googleplay/answer/3139562>`_ on
-how many different devices you can associate with an account, you might want to
-control what device ID is used. You can set the ``gmusic/deviceid`` config to
-e.g. the device ID from your phone where you also use Google Play Music::
+Google Play Music requires all clients to provide a device ID. By
+default, Mopidy-GMusic will connect using your system's MAC address
+and grab the most recently used device ID. As Google
+`puts some limits <https://support.google.com/googleplay/answer/3139562>`_
+on how many different devices you can associate with an account, you
+might want to control what device ID is used. You can set the
+``gmusic/deviceid`` config to e.g. the device ID from your phone where
+you also use Google Play Music::
 
     [gmusic]
     deviceid = 0123456789abcdef
 
-The Android device ID is a 16 character long string identifying the Android
-device registered for Google Play Music, excluding the ``0x`` prefix. You can
-obtain this ID by dialing ``*#*#8255#*#*`` on your phone (see the aid) or using
-this `app <https://play.google.com/store/apps/details?id=com.evozi.deviceid>`_
-(see the Google Service Framework ID Key).
+Both iOS and Android devices will be displayed on a successful login
+in their sanitized form.
 
-On iOS the device ID is an UUID with the ``ios:`` prefix included. (TODO:
-Include instructions on how to retrieve this.)
+In its raw form, the Android device ID is a 16 character long string
+identifying the Android device registered for Google Play Music,
+excluding the ``0x`` prefix. The iOS device ID is an UUID with the
+``ios:`` prefix included.
 
 
 Usage


### PR DESCRIPTION
Yes, I realize I'm the maintainer... I'm opening this PR mostly as an RFC to make sure this isn't a really bad idea.

One of the most common problems when dealing with All Access is that the device ID isn't set. We attempt to create one based on the MAC address, but it would probably be better to use one that already exists if possible.

Possible reasons this could be bad: It implicitly uses another device's ID, which might be frowned upon a little more by the GMusic team.