### PR TITLE
Update name of "promoted" playlist to "Thumbs up"

### DIFF
--- a/mopidy_gmusic/playlists.py
+++ b/mopidy_gmusic/playlists.py
@@ -47,14 +47,15 @@ class GMusicPlaylistsProvider(backend.PlaylistsProvider):
             mopidy_track = self.backend.library._to_mopidy_track(track)
             library_tracks[track['id']] = mopidy_track
 
-        # add thumbs up playlist
+        # add "Thumbs up" playlist... It appears that gmusic api's 
+        #get_promoted_songs == Thumbs up playlist 
         tracks = []
         for track in self.backend.session.get_promoted_songs():
             tracks.append(self.backend.library._to_mopidy_track(track))
 
         if len(tracks) > 0:
             uri = 'gmusic:playlist:promoted'
-            playlists[uri] = Playlist(uri=uri, name='Promoted', tracks=tracks)
+            playlists[uri] = Playlist(uri=uri, name='Thumbs up', tracks=tracks)
 
         # load user playlists
         for playlist in self.backend.session.get_all_user_playlist_contents():

--- a/mopidy_gmusic/playlists.py
+++ b/mopidy_gmusic/playlists.py
@@ -47,8 +47,8 @@ class GMusicPlaylistsProvider(backend.PlaylistsProvider):
             mopidy_track = self.backend.library._to_mopidy_track(track)
             library_tracks[track['id']] = mopidy_track
 
-        # add "Thumbs up" playlist... It appears that gmusic api's 
-        #get_promoted_songs == Thumbs up playlist 
+        # add "Thumbs up" playlist... It appears that gmusic api's
+        # get_promoted_songs == Thumbs up playlist
         tracks = []
         for track in self.backend.session.get_promoted_songs():
             tracks.append(self.backend.library._to_mopidy_track(track))


### PR DESCRIPTION
The contents of the promoted playlist from gmusic api's get_promoted_songs() are identical to the songs in Google's "Thumbs Up".  Google doesn't have a "promoted" playlist anymore.  Now the playlist name reflects that.
