### PR TITLE
Workaround invalid songs

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -497,13 +497,13 @@ class GMusicLibraryProvider(backend.LibraryProvider):
             raise ValueError
         return Track(
             uri='gmusic:track:' + track_id,
-            name=song['title'],
+            name=song.get('title', 'Unknown'),
             artists=[self._to_mopidy_artist(song)],
             album=self._to_mopidy_album(song),
             track_no=song.get('trackNumber', 1),
             disc_no=song.get('discNumber', 1),
             date=unicode(song.get('year', 0)),
-            length=int(song['durationMillis']),
+            length=int(song.get('durationMillis', '0')),
             bitrate=320)
 
     def _to_mopidy_album(self, song):


### PR DESCRIPTION
A song can be corrupted. By catching KeyError, we avoid the
thread to crash.

This allow for example to complete properly a refresh of the
songs list.