### PR TITLE
Check if track_id is correct

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -496,7 +496,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         track_id = song.get('id', song.get('nid'))
         if track_id is None:
             raise ValueError
-        if track_id[0] != "T":
+        if track_id[0] != "T" and "-" not in track_id:
             track_id = "T"+track_id
         return Track(
             uri='gmusic:track:' + track_id,

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -496,6 +496,8 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         track_id = song.get('id', song.get('nid'))
         if track_id is None:
             raise ValueError
+        if track_id[0] != "T":
+            track_id = "T"+track_id
         return Track(
             uri='gmusic:track:' + track_id,
             name=song['title'],


### PR DESCRIPTION
gmusicapi sometimes returns weird track_ids, this should catch those.

Not an ideal solution, but until Google or gmusicapi fixes this bug mopidy-gmusic will continue to work

fixes #174