### PR TITLE
Document refresh configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,13 @@ are the default config values::
     # Limit the number or tracks for each radio station
     radio_tracks_count = 25
 
+The library and playlists are automatically refresh at regular intervals. Refreshing can be CPU-intensive on very low-powered machines (eg Raspberry Pi Zero). The intervals can be configured::
+
+    [gmusic]
+    # How often to refresh the library, in minutes
+    refresh_library = 1440
+    # How often to refresh playlists, in minutes
+    refresh_playlists = 60
 
 Usage
 =====


### PR DESCRIPTION
I was going to add a feature to allow the refresh intervals to be configurable, but looking at the code, I realised it already is, just undocumented.
I was finding that the playlist refresh every 60 minutes was causing the CPU to max out on my Pi Zero, causing it to be unusable for a couple of minutes. I mentioned that in case anyone else encounters the same issue.