### PR TITLE
Fix track filtering

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -528,21 +528,21 @@ class GMusicLibraryProvider(backend.LibraryProvider):
                     )
 
                 if field == "uri":
-                    result_tracks = filter(uri_filter, result_tracks)
+                    result_tracks = list(filter(uri_filter, result_tracks))
                 elif field == "track_name":
-                    result_tracks = filter(track_name_filter, result_tracks)
+                    result_tracks = list(filter(track_name_filter, result_tracks))
                 elif field == "album":
-                    result_tracks = filter(album_filter, result_tracks)
+                    result_tracks = list(filter(album_filter, result_tracks))
                 elif field == "artist":
-                    result_tracks = filter(artist_filter, result_tracks)
+                    result_tracks = list(filter(artist_filter, result_tracks))
                 elif field == "albumartist":
-                    result_tracks = filter(albumartist_filter, result_tracks)
+                    result_tracks = list(filter(albumartist_filter, result_tracks))
                 elif field == "track_no":
-                    result_tracks = filter(track_no_filter, result_tracks)
+                    result_tracks = list(filter(track_no_filter, result_tracks))
                 elif field == "date":
-                    result_tracks = filter(date_filter, result_tracks)
+                    result_tracks = list(filter(date_filter, result_tracks))
                 elif field == "any":
-                    result_tracks = filter(any_filter, result_tracks)
+                    result_tracks = list(filter(any_filter, result_tracks))
                 else:
                     raise LookupError("Invalid lookup field: %s" % field)
 

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -530,13 +530,17 @@ class GMusicLibraryProvider(backend.LibraryProvider):
                 if field == "uri":
                     result_tracks = list(filter(uri_filter, result_tracks))
                 elif field == "track_name":
-                    result_tracks = list(filter(track_name_filter, result_tracks))
+                    result_tracks = list(
+                        filter(track_name_filter, result_tracks)
+                    )
                 elif field == "album":
                     result_tracks = list(filter(album_filter, result_tracks))
                 elif field == "artist":
                     result_tracks = list(filter(artist_filter, result_tracks))
                 elif field == "albumartist":
-                    result_tracks = list(filter(albumartist_filter, result_tracks))
+                    result_tracks = list(
+                        filter(albumartist_filter, result_tracks)
+                    )
                 elif field == "track_no":
                     result_tracks = list(filter(track_no_filter, result_tracks))
                 elif field == "date":

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -482,7 +482,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         result_tracks = self.tracks.values()
 
         for (field, values) in query.items():
-            if not hasattr(values, "__iter__"):
+            if not isinstance(values, list):
                 values = [values]
             # FIXME this is bound to be slow for large libraries
             for value in values:


### PR DESCRIPTION
Fixes #231 

I guess these are things that changed with Python 3.

The `filter()` function now returns a `filter` object, rather than a list, so it has to be converted to a `list` before it can be filtered again in the loop.

It seems that a string is iterable, so we need to differentiate between a list and a string, we need to specifically check is `values` is a list, not just if it is iterable. 