### PR TITLE
Don't use inconsistent `albumId` or `artistId`

### DIFF
--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -373,6 +373,8 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         return sorted(tracks, key=sorter)
 
     def refresh(self, uri=None):
+        logger.info("Refreshing library")
+
         self.tracks = {}
         self.albums = {}
         self.artists = {}
@@ -406,6 +408,11 @@ class GMusicLibraryProvider(backend.LibraryProvider):
             if not artist_found:
                 for artist in album.artists:
                     self.artists[artist.uri] = artist
+
+        logger.info("Loaded "
+                   f"{len(self.artists)} artists, "
+                   f"{len(self.albums)} albums, "
+                   f"{len(self.tracks)} tracks from Google Play Music")
 
     def search(self, query=None, uris=None, exact=False):
         if exact:

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -409,10 +409,12 @@ class GMusicLibraryProvider(backend.LibraryProvider):
                 for artist in album.artists:
                     self.artists[artist.uri] = artist
 
-        logger.info("Loaded "
-                    f"{len(self.artists)} artists, "
-                    f"{len(self.albums)} albums, "
-                    f"{len(self.tracks)} tracks from Google Play Music")
+        logger.info(
+            "Loaded "
+            f"{len(self.artists)} artists, "
+            f"{len(self.albums)} albums, "
+            f"{len(self.tracks)} tracks from Google Play Music"
+        )
 
     def search(self, query=None, uris=None, exact=False):
         if exact:

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -410,9 +410,9 @@ class GMusicLibraryProvider(backend.LibraryProvider):
                     self.artists[artist.uri] = artist
 
         logger.info("Loaded "
-                   f"{len(self.artists)} artists, "
-                   f"{len(self.albums)} albums, "
-                   f"{len(self.tracks)} tracks from Google Play Music")
+                    f"{len(self.artists)} artists, "
+                    f"{len(self.albums)} albums, "
+                    f"{len(self.tracks)} tracks from Google Play Music")
 
     def search(self, query=None, uris=None, exact=False):
         if exact:

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -585,7 +585,7 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         artist = self._to_mopidy_album_artist(song)
         date = str(song.get("year", 0))
 
-        album_id = create_id(artist.name + name + date)
+        album_id = create_id(f"{artist.name}|{name}|{date}")
 
         uri = "gmusic:album:" + album_id
         return Album(

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -585,9 +585,9 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         artist = self._to_mopidy_album_artist(song)
         date = str(song.get("year", 0))
 
-        album_id = song.get("albumId")
-        if album_id is None:
-            album_id = create_id(artist.name + name + date)
+        #album_id = song.get("albumId")
+        #if album_id is None:
+        album_id = create_id(artist.name + name + date)
 
         uri = "gmusic:album:" + album_id
         return Album(
@@ -601,11 +601,11 @@ class GMusicLibraryProvider(backend.LibraryProvider):
 
     def _to_mopidy_artist(self, song):
         name = song.get("artist", "")
-        artist_id = song.get("artistId")
-        if artist_id is not None:
-            artist_id = artist_id[0]
-        else:
-            artist_id = create_id(name)
+        #artist_id = song.get("artistId")
+        #if artist_id is not None:
+        #    artist_id = artist_id[0]
+        #else:
+        artist_id = create_id(name)
         uri = "gmusic:artist:" + artist_id
         return Artist(uri=uri, name=name)
 

--- a/mopidy_gmusic/library.py
+++ b/mopidy_gmusic/library.py
@@ -585,8 +585,6 @@ class GMusicLibraryProvider(backend.LibraryProvider):
         artist = self._to_mopidy_album_artist(song)
         date = str(song.get("year", 0))
 
-        #album_id = song.get("albumId")
-        #if album_id is None:
         album_id = create_id(artist.name + name + date)
 
         uri = "gmusic:album:" + album_id
@@ -601,10 +599,6 @@ class GMusicLibraryProvider(backend.LibraryProvider):
 
     def _to_mopidy_artist(self, song):
         name = song.get("artist", "")
-        #artist_id = song.get("artistId")
-        #if artist_id is not None:
-        #    artist_id = artist_id[0]
-        #else:
         artist_id = create_id(name)
         uri = "gmusic:artist:" + artist_id
         return Artist(uri=uri, name=name)


### PR DESCRIPTION
Fixes #139
Fixes #206

The `albumId` or `artistId` doesn't always exist. They sometimes exists for some tracks in an album, but not others. This causes new IDs to be generated, which means those tracks are shown as being by a separate artist and in a separate album.

All I've done here is make it always generate an `artistId` and `albumId`, never using the one that may exist from gmusic.

Does anyone know if this is an issue for All Access (called subscription now?)? I'm thinking that the IDs might always be sent back for AA tracks. If that's the case, we should probably do something like:

```
if all_access:
    album_id = song.get("albumId")
else:
    album_id = create_id(artist.name + name + date)
```